### PR TITLE
Site::Twitter: handle "Access denied" error

### DIFF
--- a/lib/Amon2/Auth/Site/Twitter.pm
+++ b/lib/Amon2/Auth/Site/Twitter.pm
@@ -46,6 +46,9 @@ sub callback {
 	my $nt = $self->_nt();
 	$nt->request_token($cookie->[0]);
 	$nt->request_token_secret($cookie->[1]);
+    if (my $denied = $c->req->param('denied')) {
+        return $callback->{on_error}->("Access denied");
+    }
 	my $verifier = $c->req->param('oauth_verifier');
     my ($access_token, $access_token_secret, $user_id, $screen_name) = eval {
         $nt->request_access_token(verifier => $verifier);


### PR DESCRIPTION
oauth_callback urlにoauth_verifierパラメータがない場合にon_errorが呼ばれずに例外が発生してしまう問題を修正しました。
(Twitterの認証を許可しなかったときに、アプリに戻ることで発生します)
